### PR TITLE
[macos] Fix printf differences for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - sudo ./make.sh install
   - cd ..
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then CC=clang++-5.0; Ld=ld.lld-5.0; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CC=clang++; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then CC=clang++; brew update; brew install lz4; fi
 
 
 script: make LD=$Ld CC=$CC

--- a/Cpu.cpp
+++ b/Cpu.cpp
@@ -37,7 +37,7 @@ void mmioHook(uc_engine *uc, uc_mem_type type, gptr address, uint32_t size, gptr
 			
 			break;
 		case UC_MEM_WRITE:
-			LOG_DEBUG(Cpu, "MMIO Write at " ADDRFMT " size %x data %lx", physicalAddress, size, value);
+			LOG_DEBUG(Cpu, "MMIO Write at " ADDRFMT " size %x data " LONGFMT, physicalAddress, size, value);
 			mmio->write(physicalAddress, size, value);
 			break;
 	}

--- a/Ctu.h
+++ b/Ctu.h
@@ -47,8 +47,13 @@ const gptr TERMADDR = 1ULL << 61;
 
 #define FOURCC(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | (a))
 
-#define ADDRFMT "%016lx"
-#define LONGFMT "%lx"
+#ifdef __APPLE__
+	#define ADDRFMT "%016llx"
+	#define LONGFMT "%llx"
+#else
+	#define ADDRFMT "%016lx"
+	#define LONGFMT "%lx"
+#endif
 
 enum LogLevel {
 	None = 0,

--- a/GdbStub.cpp
+++ b/GdbStub.cpp
@@ -243,7 +243,7 @@ void GdbStub::removeBreakpoint(BreakpointType type, gptr addr) {
 
 	auto bp = p.find(addr);
 	if(bp != p.end()) {
-		LOG_DEBUG(GdbStub, "gdb: removed a breakpoint: %016lx bytes at %016lx of type %d",
+		LOG_DEBUG(GdbStub, "gdb: removed a breakpoint: " ADDRFMT " bytes at " ADDRFMT " of type %d",
 				  bp->second.len, bp->second.addr, type);
 		ctu->cpu.removeBreakpoint(bp->second.hook);
 		p.erase(addr);
@@ -275,7 +275,7 @@ bool GdbStub::checkBreakpoint(gptr addr, BreakpointType type) {
 
 		if(bp->second.active && (addr >= bp->second.addr && addr < bp->second.addr + len)) {
 			LOG_DEBUG(GdbStub,
-					  "Found breakpoint type %d @ %016lx, range: %016lx - %016lx (%d bytes)", type,
+					  "Found breakpoint type %d @ " ADDRFMT ", range: " ADDRFMT " - " ADDRFMT " (%d bytes)", type,
 					  addr, bp->second.addr, bp->second.addr + len, (uint32_t) len);
 			return true;
 		}
@@ -508,7 +508,7 @@ void GdbStub::readMemory() {
 	start_offset = addr_pos + 1;
 	auto len = hexToInt(start_offset, static_cast<uint32_t>((commandBuffer + commandLength) - start_offset));
 
-	LOG_DEBUG(GdbStub, "gdb: addr: %016lx len: %016lx", addr, len);
+	LOG_DEBUG(GdbStub, "gdb: addr: " ADDRFMT " len: " ADDRFMT, addr, len);
 
 	if(len * 2 > sizeof(reply)) {
 		sendReply("E01");
@@ -580,7 +580,7 @@ bool GdbStub::commitBreakpoint(BreakpointType type, gptr addr, uint32_t len) {
 
 	p.insert({addr, breakpoint});
 
-	LOG_DEBUG(GdbStub, "gdb: added %d breakpoint: %016lx bytes at %016lx", type, breakpoint.len,
+	LOG_DEBUG(GdbStub, "gdb: added %d breakpoint: " ADDRFMT " bytes at " ADDRFMT, type, breakpoint.len,
 			  breakpoint.addr);
 
 	return true;

--- a/ipcimpl/lm.cpp
+++ b/ipcimpl/lm.cpp
@@ -1,5 +1,4 @@
 #include "Ctu.h"
-#include <byteswap.h>
 
 /*$IPC$
 partial nn::lm::ILogger {


### PR DESCRIPTION
The changes in this pull request get the macos build closer to compiling on travis, but there is still an issue seen here: https://travis-ci.org/vgmoose/Mephisto/jobs/302287385

Changes made:
- b1007d4 should fix the mac printf issues mentioned in https://github.com/reswitched/Mephisto/pull/11
- 76d6206 adds lz4 as a brew requirement in travis.yml
- 2f5d055 removes another include to byteorder.h (per reswitched#10)

The (hopefully) last remaining issue seems to have to do with `sockaddr`'s `sa_family` on osx looking like:
```C
struct sockaddr {
    __uint8_t   sa_len;     /* total length */
    sa_family_t sa_family;  /* [XSI] address family */
    char        sa_data[14];    /* [XSI] addr value (actually larger) */
};
```
Where `sa_family_t` is defined as `typedef __uint8_t       sa_family_t;`

On Linux I think it's defined as:
```C
struct sockaddr
  {
    unsigned short int sa_family;
    unsigned char sa_data[14];
  };
```

So the Mac struct contains two 8-bit values whereas the Linux struct contains one 16-bit value? The issue comes up in 5 places in `ipcimpl/bsd.cpp`  when trying to call [htons](https://linux.die.net/man/3/htons) on `addr->sa_family`, which I don't think makes sense if it's 8-bit. 

On macos maybe the `addr->sa_family` and `addr->sa_len` values need to be swapped as opposed to the htons? I'm not sure. If these htons lines are commented out, it compiles and runs on osx, but sockets are probably broken.